### PR TITLE
Implement solution for deduplication of random results #7

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -3,27 +3,18 @@
 #
 # Before building the docker image run:
 #
-# mvn package
+# mvn package -Dconfig.secret.path=<full path to secret file>
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/sample-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/mpc-rest-api-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/sample-jvm
+# docker run -i --rm -p 8090:8090 quarkus/mpc-rest-api-jvm
 #
 ###
 FROM fabric8/java-alpine-openjdk8-jre
-  
-## Where to source the cert file
-ARG LOCAL_CRT=config/local.crt
-ENV LOCAL_CRT ${LOCAL_CRT}
-
-## copy to a temp ssl dir for container usage
-WORKDIR /tmp
-RUN mkdir ssl
-COPY $LOCAL_CRT ssl/local.crt
 
 ## Where to copy the secret file, default to tmp
 ARG SECRET_LOCATION=/tmp

--- a/src/main/java/org/eclipsefoundation/marketplace/helper/ResponseHelper.java
+++ b/src/main/java/org/eclipsefoundation/marketplace/helper/ResponseHelper.java
@@ -1,0 +1,94 @@
+/* Copyright (c) 2019 Eclipse Foundation and others.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License 2.0
+ * which is available at http://www.eclipse.org/legal/epl-v20.html,
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipsefoundation.marketplace.helper;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.json.bind.Jsonb;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.DatatypeConverter;
+
+import org.eclipsefoundation.marketplace.model.RequestWrapper;
+import org.eclipsefoundation.marketplace.service.CachingService;
+
+/**
+ * Helper class that transforms data into a response usable for the RESTeasy
+ * container. Uses injected JSON-B serializer and caching service to get current
+ * information on cache data.
+ * 
+ * @author Martin Lowe
+ *
+ */
+@ApplicationScoped
+public class ResponseHelper {
+
+	private static final MessageDigest DIGEST;
+	static {
+		try {
+			DIGEST = MessageDigest.getInstance("md5");
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("Could not create an MD5 hash digest");
+		}
+	}
+	
+	@Inject
+	Jsonb jsonb;
+	@Inject
+	CachingService<?> cachingService;
+
+	/**
+	 * Builds a response using passed data. Uses references to the caching service
+	 * and the current request to add information about ETags and Cache-Control
+	 * headers.
+	 * 
+	 * @param id      the ID of the object to be stored in cache
+	 * @param wrapper the query parameters for the current request
+	 * @param data    the data to attach to the response
+	 * @return a complete response object for the given data and request.
+	 */
+	public Response build(String id, RequestWrapper wrapper, Object data) {
+		// set default cache control flags for API responses
+		CacheControl cc = new CacheControl();
+		cc.setNoStore(wrapper.isCacheBypass());
+
+		if (!cc.isNoStore()) {
+			cc.setMaxAge((int) cachingService.getMaxAge());
+			// get the TTL for the current entry
+			Optional<Long> ttl = cachingService.getExpiration(id, wrapper);
+			if (!ttl.isPresent()) {
+				return Response.serverError().build();
+			}
+
+			// serialize the data to get an etag
+			String content = jsonb.toJson(Objects.requireNonNull(data));
+			// ingest the content and hash to create an etag for current content
+			String hash;
+			synchronized (this) {
+				DIGEST.update(content.getBytes(StandardCharsets.UTF_8));
+				hash = DatatypeConverter.printHexBinary(DIGEST.digest());
+				DIGEST.reset();
+			}
+			
+			// check if etag matches
+			String etag = wrapper.getHeader("Etag");
+			if (hash.equals(etag)) {
+				return Response.notModified(etag).cacheControl(cc).expires(new Date(ttl.get())).build();
+			}
+			// return a response w/ the generated etag
+			return Response.ok(data).tag(hash).cacheControl(cc).expires(new Date(ttl.get())).build();
+		}
+		return Response.ok(data).cacheControl(cc).build();
+	}
+}

--- a/src/main/java/org/eclipsefoundation/marketplace/model/RequestWrapper.java
+++ b/src/main/java/org/eclipsefoundation/marketplace/model/RequestWrapper.java
@@ -23,6 +23,7 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipsefoundation.marketplace.namespace.DeprecatedHeader;
 import org.eclipsefoundation.marketplace.namespace.RequestHeaderNames;
+import org.eclipsefoundation.marketplace.request.CacheBypassFilter;
 import org.jboss.resteasy.core.ResteasyContext;
 
 /**
@@ -168,7 +169,18 @@ public class RequestWrapper {
 	}
 
 	/**
-	 * Retrieve a request header value as an optional value.
+	 * Check whether the current request should bypass caching
+	 * 
+	 * @return true if cache should be bypassed, otherwise false
+	 */
+	public boolean isCacheBypass() {
+		Object attr = request.getAttribute(CacheBypassFilter.ATTRIBUTE_NAME);
+		// if we have the attribute set on the request, return it. otherwise, false.
+		return attr instanceof Boolean ? (boolean) attr : Boolean.FALSE;
+	}
+
+	/**
+	 * Retrieve a request header value.
 	 * 
 	 * @param key the headers key value
 	 * @return the value, or an empty optional if missing.

--- a/src/main/java/org/eclipsefoundation/marketplace/model/SortOrder.java
+++ b/src/main/java/org/eclipsefoundation/marketplace/model/SortOrder.java
@@ -53,4 +53,24 @@ public enum SortOrder {
 		}
 		return NONE;
 	}
+
+	/**
+	 * Gets the SortOrder value associated with a sort parameter value if one
+	 * exists.
+	 * 
+	 * @param value the value of the sort parameter
+	 * @return the SortOrder associated with the request, or
+	 *         {@linkplain SortOrder.NONE}
+	 */
+	public static SortOrder getOrderFromValue(String value) {
+		// get the index of the space separator 
+		int idx = value.indexOf(' ');
+		// check if the sort string matches the RANDOM sort order
+		if (SortOrder.RANDOM.equals(SortOrder.getOrderByName(value))) {
+			return SortOrder.RANDOM;
+		} else if (idx > 0) {
+			return SortOrder.getOrderByName(value.substring(idx + 1));
+		}
+		return SortOrder.NONE;
+	}
 }

--- a/src/main/java/org/eclipsefoundation/marketplace/request/CacheBypassFilter.java
+++ b/src/main/java/org/eclipsefoundation/marketplace/request/CacheBypassFilter.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2019 Eclipse Foundation and others.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License 2.0
+ * which is available at http://www.eclipse.org/legal/epl-v20.html,
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipsefoundation.marketplace.request;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipsefoundation.marketplace.model.SortOrder;
+import org.eclipsefoundation.marketplace.namespace.UrlParameterNames;
+
+/**
+ * Checks passed parameters and if any match one of the criteria for bypassing
+ * caching, an attribute will be set to the request to skip cache requests and
+ * instead directly return results.
+ * 
+ * @author Martin Lowe
+ *
+ */
+@Provider
+public class CacheBypassFilter implements ContainerRequestFilter {
+	public static final String ATTRIBUTE_NAME = "bypass-cache";
+
+	@Context
+	HttpServletRequest request;
+
+	@Context
+	HttpServletResponse response;
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		// check for random sort order, which always bypasses cache
+		String[] sortVals = request.getParameterValues(UrlParameterNames.SORT);
+		if (sortVals != null) {
+			for (String sortVal : sortVals) {
+				// check if the sort order for request matches RANDOM
+				if (SortOrder.RANDOM.equals(SortOrder.getOrderFromValue(sortVal))) {
+					setBypass();
+					return;
+				}
+			}
+		}
+		request.setAttribute(ATTRIBUTE_NAME, Boolean.FALSE);
+	}
+
+	private void setBypass() {
+		request.setAttribute(ATTRIBUTE_NAME, Boolean.TRUE);
+		// no-store should be used as cache bypass should not return
+		response.setHeader("Cache-Control", "no-store");
+	}
+}

--- a/src/main/java/org/eclipsefoundation/marketplace/resource/ListingVersionResource.java
+++ b/src/main/java/org/eclipsefoundation/marketplace/resource/ListingVersionResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.Response.Status;
 import org.eclipsefoundation.marketplace.dao.MongoDao;
 import org.eclipsefoundation.marketplace.dto.ListingVersion;
 import org.eclipsefoundation.marketplace.dto.filter.DtoFilter;
+import org.eclipsefoundation.marketplace.helper.ResponseHelper;
 import org.eclipsefoundation.marketplace.helper.StreamHelper;
 import org.eclipsefoundation.marketplace.model.Error;
 import org.eclipsefoundation.marketplace.model.MongoQuery;
@@ -58,10 +59,12 @@ public class ListingVersionResource {
 	RequestWrapper params;
 	@Inject
 	DtoFilter<ListingVersion> dtoFilter;
+	@Inject
+	ResponseHelper responseBuider;
 
 	@GET
 	public Response select() {
-		MongoQuery<ListingVersion> q = new MongoQuery<>(params, dtoFilter, cachingService);
+		MongoQuery<ListingVersion> q = new MongoQuery<>(params, dtoFilter);
 		// retrieve the possible cached object
 		Optional<List<ListingVersion>> cachedResults = cachingService.get("all", params,
 				() -> StreamHelper.awaitCompletionStage(dao.get(q)));
@@ -82,7 +85,7 @@ public class ListingVersionResource {
 	 */
 	@PUT
 	public Response putListingVersion(ListingVersion listingVersion) {
-		MongoQuery<ListingVersion> q = new MongoQuery<>(params, dtoFilter, cachingService);
+		MongoQuery<ListingVersion> q = new MongoQuery<>(params, dtoFilter);
 		// add the object, and await the result
 		StreamHelper.awaitCompletionStage(dao.add(q, Arrays.asList(listingVersion)));
 
@@ -102,7 +105,7 @@ public class ListingVersionResource {
 	public Response select(@PathParam("listingVersionId") String listingVersionId) {
 		params.addParam(UrlParameterNames.ID, listingVersionId);
 
-		MongoQuery<ListingVersion> q = new MongoQuery<>(params, dtoFilter, cachingService);
+		MongoQuery<ListingVersion> q = new MongoQuery<>(params, dtoFilter);
 		// retrieve a cached version of the value for the current listing
 		Optional<List<ListingVersion>> cachedResults = cachingService.get(listingVersionId, params,
 				() -> StreamHelper.awaitCompletionStage(dao.get(q)));
@@ -127,7 +130,7 @@ public class ListingVersionResource {
 	public Response delete(@PathParam("listingVersionId") String listingVersionId) {
 		params.addParam(UrlParameterNames.ID, listingVersionId);
 
-		MongoQuery<ListingVersion> q = new MongoQuery<>(params, dtoFilter, cachingService);
+		MongoQuery<ListingVersion> q = new MongoQuery<>(params, dtoFilter);
 		// delete the currently selected asset
 		DeleteResult result = StreamHelper.awaitCompletionStage(dao.delete(q));
 		if (result.getDeletedCount() == 0 || !result.wasAcknowledged()) {

--- a/src/main/java/org/eclipsefoundation/marketplace/service/CachingService.java
+++ b/src/main/java/org/eclipsefoundation/marketplace/service/CachingService.java
@@ -34,6 +34,21 @@ public interface CachingService<T> {
 	Optional<T> get(String id, RequestWrapper params, Callable<? extends T> callable);
 
 	/**
+	 * Returns the expiration date in millis since epoch.
+	 * 
+	 * @param id     the ID of the object to be stored in cache
+	 * @param params the query parameters for the current request
+	 * @return an Optional expiration date for the current object if its set. If
+	 *         there is no underlying data, then empty would be returned
+	 */
+	Optional<Long> getExpiration(String id, RequestWrapper params);
+
+	/**
+	 * @return the max age of cache entries
+	 */
+	long getMaxAge();
+
+	/**
 	 * Retrieves a set of cache keys available to the current cache.
 	 * 
 	 * @return unmodifiable set of cache entry keys.
@@ -56,18 +71,18 @@ public interface CachingService<T> {
 	 * Generates a unique key based on the id of the item/set of items to be stored,
 	 * as well as any passed parameters.
 	 * 
-	 * @param id  identity string of the item to cache
-	 * @param qps parameters associated with the request for information
+	 * @param id      identity string of the item to cache
+	 * @param wrapper parameters associated with the request for information
 	 * @return the unique cache key for the request.
 	 */
-	default String getCacheKey(String id, RequestWrapper qps) {
+	default String getCacheKey(String id, RequestWrapper wrapper) {
 		StringBuilder sb = new StringBuilder();
-		sb.append('[').append(qps.getEndpoint()).append(']');
+		sb.append('[').append(wrapper.getEndpoint()).append(']');
 		sb.append("id:").append(id);
 
 		// join all the non-empty params to the key to create distinct entries for
 		// filtered values
-		qps.asMap().entrySet().stream().filter(e -> !e.getValue().isEmpty())
+		wrapper.asMap().entrySet().stream().filter(e -> !e.getValue().isEmpty())
 				.map(e -> e.getKey() + '=' + StringUtils.join(e.getValue(), ','))
 				.forEach(s -> sb.append('|').append(s));
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,6 +1,6 @@
 ## OAUTH CONFIG
 quarkus.oauth2.enabled=true
-quarkus.oauth2.introspection-url=https://accounts.php56.dev.docker/oauth2/introspect
+quarkus.oauth2.introspection-url=http://accounts.php56.dev.docker/oauth2/introspect
 
 ## LOGGER CONFIG
 quarkus.log.file.enable=true
@@ -9,7 +9,7 @@ quarkus.log.level=TRACE
 quarkus.log.file.path=/tmp/logs/quarkus.log
 
 ## DATASOURCE CONFIG
-quarkus.mongodb.connection-string=mongodb://localhost:27017
+quarkus.mongodb.connection-string=mongodb://192.168.1.178:27017
 mongodb.database=mpc
 mongodb.default.limit=25
 mongodb.default.limit.max=100


### PR DESCRIPTION
Added Cache-Control and Etag header values for responses. Added no-store
to random sort order requests, as well as a cache bypass mechanism. This
mechanism currently only triggers when sort order is set to random.
Added calls to cache service to maintain expiration times as well as
accessor for max age.

Change-Id: If7b4b57c7e265fe69ef4fdefec4249ea55bcdf5d
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>