### PR TITLE
Do not include secrets in the Docker image #71

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -11,22 +11,12 @@
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8090:8090 quarkus/mpc-rest-api-jvm
+# docker run -i --rm -p 8090:8090 -v <full path to secret file folder>:/run/secrets --env config.secret.path=/run/secrets/secret.properties quarkus/mpc-rest-api-jvm
 #
 ###
 FROM fabric8/java-alpine-openjdk8-jre
 
-## Where to copy the secret file, default to tmp
-ARG SECRET_LOCATION=/tmp
-ENV SECRET_LOCATION ${SECRET_LOCATION}
-## Where to source the secret.properties file
-ARG LOCAL_SECRETS=config/secret.properties
-ENV LOCAL_SECRETS ${LOCAL_SECRETS}
-## Copy the secret.properties to the given location
-WORKDIR $SECRET_LOCATION
-COPY $LOCAL_SECRETS secret.properties
-
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dconfig.secret.path=${SECRET_LOCATION}/secret.properties"
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar

--- a/src/main/java/org/eclipsefoundation/marketplace/config/SecretConfigSource.java
+++ b/src/main/java/org/eclipsefoundation/marketplace/config/SecretConfigSource.java
@@ -40,8 +40,12 @@ public class SecretConfigSource implements ConfigSource {
 		if (secrets == null) {
 			this.secrets = new HashMap<>();
 			String secretPath = System.getProperty("config.secret.path");
+			// Fallback to checking env if not set in JVM
 			if (StringUtils.isEmpty(secretPath)) {
-				LOGGER.error("Configuration 'config.secret.path' not set, cannot generate secret properties");
+				secretPath = System.getenv("config.secret.path");
+			}
+			if (StringUtils.isEmpty(secretPath)) {
+				LOGGER.error("Configuration 'config.secret.path' not set, cannot generate secret properties.");
 				return this.secrets;
 			}
 			// load the secrets file in


### PR DESCRIPTION
Updated SecretConfigSource to check JVM then env vars for secret
location. Removed calls in dockerfile to contain secrets, and instead
expect it to be mounted as a volume. Instructions in docker file has
been updated.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>