### PR TITLE
Fix for #80 - /listings/id should return object instead of list

### DIFF
--- a/src/main/java/org/eclipsefoundation/marketplace/resource/ListingResource.java
+++ b/src/main/java/org/eclipsefoundation/marketplace/resource/ListingResource.java
@@ -140,7 +140,7 @@ public class ListingResource {
 			throw new NoResultException("Could not find any documents with ID " + listingId);
 		}
 		// return the results as a response
-		return responseBuider.build(listingId, params, cachedResults.get());
+		return responseBuider.build(listingId, params, cachedResults.get().get(0));
 	}
 
 	/**


### PR DESCRIPTION
Fixes #80: just return the first object returned from the cache/db. 

I don't think there should ever be a case where we have to deal with more than one value. Otherwise that would be a server error in my mind - we could check that beforehand if desired...